### PR TITLE
Remove broken link and rename React Native section to Quickstart

### DIFF
--- a/components/layoutData.tsx
+++ b/components/layoutData.tsx
@@ -10,8 +10,7 @@ type Data = {
 
 export const sidebarData: SidebarData = [
     { isHeader: true, title: 'Getting Started', name: 'getting-started' },
-    { title: 'React Native', name: 'integration', href: '/' },
-    { title: 'Expo', name: 'expo', href: '/expo' },
+    { title: 'Quickstart', name: 'integration', href: '/' },
     { title: 'Features', name: 'features', href: '/features' },
 
     { isHeader: true, title: 'Dashboard', name: 'dashboard' },


### PR DESCRIPTION
In #5 I missed removing the Expo link from the sidebar after collapsing it into the quickstart. 

In this PR, I remove that link and also rename the "React Native" section there to "Quickstart", since that is a better name (and the name used on the page itself) for it now that there is no distinct "Expo" section.

<img width="1487" alt="image" src="https://github.com/vexotech/docs/assets/90494/d6d1743b-491d-47dd-bd51-81434e23ca58">
