### PR TITLE
Update page titles for SEO

### DIFF
--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -1,4 +1,9 @@
 import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'Changelog | Vexo Documentation',
+}
 
 export default function Home() {
     return <Docs />

--- a/app/contact-vexo/page.tsx
+++ b/app/contact-vexo/page.tsx
@@ -1,4 +1,9 @@
 import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'Contact Vexo | Vexo Documentation',
+}
 
 export default function Home() {
     return <Docs />

--- a/app/get-started/introduction/page.tsx
+++ b/app/get-started/introduction/page.tsx
@@ -1,4 +1,9 @@
 import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'Introduction | Vexo Documentation',
+}
 
 export default function Home() {
     return <Docs />

--- a/app/get-started/quick-start/page.tsx
+++ b/app/get-started/quick-start/page.tsx
@@ -1,4 +1,9 @@
 import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'Quickstart | Vexo Documentation',
+}
 
 export default function Home() {
     return <Docs />

--- a/app/react-native-guide/integration/page.tsx
+++ b/app/react-native-guide/integration/page.tsx
@@ -1,4 +1,9 @@
 import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'React Native Integration | Vexo Documentation',
+}
 
 export default function Home() {
     return <Docs />

--- a/app/react-native-guide/introduction/page.tsx
+++ b/app/react-native-guide/introduction/page.tsx
@@ -1,4 +1,9 @@
 import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'React Native Introduction | Vexo Documentation',
+}
 
 export default function Home() {
     return <Docs />

--- a/app/react-native-guide/mobile-features/custom-events/page.tsx
+++ b/app/react-native-guide/mobile-features/custom-events/page.tsx
@@ -1,4 +1,9 @@
 import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'Custom Events | Vexo Documentation',
+}
 
 export default function Home() {
     return <Docs />

--- a/app/react-native-guide/mobile-features/overview/page.tsx
+++ b/app/react-native-guide/mobile-features/overview/page.tsx
@@ -1,4 +1,9 @@
 import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'Overview | Vexo Documentation',
+}
 
 export default function Home() {
     return <Docs />

--- a/app/react-native-guide/mobile-features/people/docs.mdx
+++ b/app/react-native-guide/mobile-features/people/docs.mdx
@@ -1,6 +1,6 @@
 import { DocLayout, DocImage } from '../../../../components';
 
-## People
+# People
 
 The **People** feature brings together every detail about your users in one place. Whether you’re analyzing a **React Native app** or also using **Vexo Web**, People gives you a complete and unified view of your users — right out of the box.
 

--- a/app/react-native-guide/mobile-features/people/page.tsx
+++ b/app/react-native-guide/mobile-features/people/page.tsx
@@ -1,4 +1,9 @@
 import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'People | Vexo Documentation',
+}
 
 export default function Home() {
     return <Docs />

--- a/app/react-native-guide/mobile-features/session-replays-heatmaps/page.tsx
+++ b/app/react-native-guide/mobile-features/session-replays-heatmaps/page.tsx
@@ -1,4 +1,9 @@
 import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'Session Replays | Vexo Documentation',
+}
 
 export default function Home() {
     return <Docs />

--- a/app/react-native-guide/mobile-publishing/page.tsx
+++ b/app/react-native-guide/mobile-publishing/page.tsx
@@ -1,4 +1,9 @@
 import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'Publishing your app | Vexo Documentation',
+}
 
 export default function Home() {
     return <Docs />

--- a/app/react-native-guide/mobile-settings/page.tsx
+++ b/app/react-native-guide/mobile-settings/page.tsx
@@ -1,4 +1,9 @@
 import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'Tracking information | Vexo Documentation',
+}
 
 export default function Home() {
     return <Docs />

--- a/app/settings/account-settings/page.tsx
+++ b/app/settings/account-settings/page.tsx
@@ -1,4 +1,9 @@
 import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'Account information | Vexo Documentation',
+}
 
 export default function Home() {
     return <Docs />

--- a/app/settings/billing/page.tsx
+++ b/app/settings/billing/page.tsx
@@ -1,4 +1,9 @@
 import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'Billing | Vexo Documentation',
+}
 
 export default function Home() {
     return <Docs />

--- a/app/settings/subscription/page.tsx
+++ b/app/settings/subscription/page.tsx
@@ -1,4 +1,9 @@
 import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'Subscription | Vexo Documentation',
+}
 
 export default function Home() {
     return <Docs />

--- a/app/web-guide/integration/page.tsx
+++ b/app/web-guide/integration/page.tsx
@@ -1,4 +1,9 @@
 import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'Web Integration | Vexo Documentation',
+}
 
 export default function Home() {
     return <Docs />

--- a/app/web-guide/introduction/page.tsx
+++ b/app/web-guide/introduction/page.tsx
@@ -1,4 +1,9 @@
 import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'Web Introduction | Vexo Documentation',
+}
 
 export default function Home() {
     return <Docs />


### PR DESCRIPTION
Adds page-specific metadata with unique titles for each documentation page following the pattern "[Page Name] | Vexo Documentation".

Also converts h2 to h1 on the People page.