### PR TITLE
Fix 404s and add redirects to preserve link equity

### DIFF
--- a/app/docs.mdx
+++ b/app/docs.mdx
@@ -35,6 +35,6 @@ vexo('YOUR_API_KEY');
 5. Re-build and run your app (the `vexo-analytics` package includes native code).
 6. Go to your app's page on Vexo and you should see your first event!
 
-**Wait, that's it?** Yes! That's it. With that ease of integration experience you get an incredible set of features, go [check them out](https://docs.vexo.co/features)!
+**Wait, that's it?** Yes! That's it. With that ease of integration experience you get an incredible set of features, go [check them out](/react-native-guide/mobile-features/overview)!
 
-export default ({ children }) => <DocLayout current="integration" next={{href: 'features', label: 'Supported features'}}>{children}</DocLayout>
+export default ({ children }) => <DocLayout current="integration" next={{href: '/react-native-guide/mobile-features/overview', label: 'Supported features'}}>{children}</DocLayout>

--- a/next.config.js
+++ b/next.config.js
@@ -11,5 +11,64 @@ module.exports = withMDX({
     pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
     experimental: {
         appDir: true,
-    }
+    },
+    async redirects() {
+        return [
+            {
+                source: '/features',
+                destination: '/react-native-guide/mobile-features/overview',
+                permanent: true,
+            },
+            {
+                source: '/docs',
+                destination: '/get-started/introduction',
+                permanent: true,
+            },
+            {
+                source: '/guide',
+                destination: '/get-started/introduction',
+                permanent: true,
+            },
+            {
+                source: '/getting-started',
+                destination: '/get-started/introduction',
+                permanent: true,
+            },
+            {
+                source: '/introduction',
+                destination: '/get-started/introduction',
+                permanent: true,
+            },
+            {
+                source: '/quickstart',
+                destination: '/get-started/quick-start',
+                permanent: true,
+            },
+            {
+                source: '/mobile',
+                destination: '/react-native-guide/introduction',
+                permanent: true,
+            },
+            {
+                source: '/web',
+                destination: '/web-guide/introduction',
+                permanent: true,
+            },
+            {
+                source: '/sdk',
+                destination: '/get-started/quick-start',
+                permanent: true,
+            },
+            {
+                source: '/integration',
+                destination: '/react-native-guide/integration',
+                permanent: true,
+            },
+            {
+                source: '/install',
+                destination: '/get-started/quick-start',
+                permanent: true,
+            },
+        ];
+    },
 })

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,59 @@
+{
+  "redirects": [
+    {
+      "source": "/features",
+      "destination": "/react-native-guide/mobile-features/overview",
+      "permanent": true
+    },
+    {
+      "source": "/docs",
+      "destination": "/get-started/introduction",
+      "permanent": true
+    },
+    {
+      "source": "/guide",
+      "destination": "/get-started/introduction",
+      "permanent": true
+    },
+    {
+      "source": "/getting-started",
+      "destination": "/get-started/introduction",
+      "permanent": true
+    },
+    {
+      "source": "/introduction",
+      "destination": "/get-started/introduction",
+      "permanent": true
+    },
+    {
+      "source": "/quickstart",
+      "destination": "/get-started/quick-start",
+      "permanent": true
+    },
+    {
+      "source": "/mobile",
+      "destination": "/react-native-guide/introduction",
+      "permanent": true
+    },
+    {
+      "source": "/web",
+      "destination": "/web-guide/introduction",
+      "permanent": true
+    },
+    {
+      "source": "/sdk",
+      "destination": "/get-started/quick-start",
+      "permanent": true
+    },
+    {
+      "source": "/integration",
+      "destination": "/react-native-guide/integration",
+      "permanent": true
+    },
+    {
+      "source": "/install",
+      "destination": "/get-started/quick-start",
+      "permanent": true
+    }
+  ]
+}


### PR DESCRIPTION
- Add vercel.json with 11 permanent redirects for broken/legacy URLs
- Add matching redirects to next.config.js for local dev
- Update docs.mdx to use direct URLs instead of /features redirect

Fixes /features returning 404 (has 2 referring domains from Semrush). Captures link equity from common URL patterns like /docs, /guide, /mobile, /web, /quickstart that external sites may link to.