### PR TITLE
Document heatmap segmentation (setHeatmapSegment, SDK 1.7.0)

### DIFF
--- a/app/react-native-guide/mobile-features/session-replays-heatmaps/docs.mdx
+++ b/app/react-native-guide/mobile-features/session-replays-heatmaps/docs.mdx
@@ -38,6 +38,7 @@ We also understand the context of the tap, which means:
 - The current screen it's being tapped on
 - The current version of your app
 - The phone model the device is on
+- The heatmap segment, if you've set one (see Segments below)
 
 You can select all of your app versions to see past heatmaps of your screen, and different models to understand different patterns across models adopting your app.
 
@@ -50,11 +51,43 @@ we take screenshots of the users based on app version and model device.
 We understand this is sensible data, so we encrypt the images in the server for security, and restrict the access only to yourself,
 so you have control about what happens with them, it's yours.
 
-When taking screenshots, we check that the screenshot (by app version, and device model) hasn't been uploaded yet, and discard it if it was, or upload it otherwise,
+When taking screenshots, we check that the screenshot (by app version, device model, and segment if you've set one) hasn't been uploaded yet, and discard it if it was, or upload it otherwise,
 pretty simple right?
 
 **Note:** If you are programatically showing a loading screen inside a screen as a way of loading data, it's possible for you to see a screenshot of your loading screen.
 There's nothing wrong on designing your apps this way but it will become harder for you to maintain, and we recommend against it.
 Having an independent screen that does `Loading` is a better way to go, as it isolates responsibilities from your screens, helps transitioning, and secures a better experience while loading data.
+
+### Segments
+
+**Note:** Requires `vexo-analytics` 1.7.0 or later.
+
+If the same screen renders differently depending on who's looking at it—role-based layouts, A/B test arms, tenant themes—one blended heatmap is meaningless: taps from one layout end up drawn over a screenshot of another.
+Segments solve this by letting you split heatmaps by any property you choose.
+
+Call `setHeatmapSegment` as soon as you know which segment the user belongs to, typically right after login:
+
+```js
+import { setHeatmapSegment } from 'vexo-analytics'
+
+// After login, or whenever the user's segment is known
+setHeatmapSegment(user.role) // e.g. 'admin', 'member', 'tenant-acme'
+```
+
+While a segment is set, both taps and heatmap screenshots are tagged with it, and every combination of screen, app version, device model and segment gets its own screenshot and its own pool of taps.
+Your admin layout and your member layout stop blending into a single heatmap.
+
+Passing `null`, `undefined` or `''` clears the segment, and activity goes back to being untagged.
+
+In the dashboard, the heatmap preview gains a **Segment** dropdown next to the Version and Model selectors.
+Pick a segment to see the screenshot and taps for just that variant, or pick **All** to see untagged and mixed data together—exactly what heatmaps show today.
+
+A few things to keep in mind:
+
+- Segment values are strings of at most **64 characters**. Longer values are ignored, and we'll warn you in the console.
+- An app can have up to **20 distinct segment values**. Activity using values beyond that cap is stored untagged.
+- Each segment gets its own screenshots, so segments multiply screenshot volume and count toward your plan's heatmap quota (2000 on the free tier). A few coarse segments like roles work better than high-cardinality values like user ids.
+- A screen's segmented screenshot is captured on the first visit *after* the segment is set. If you change the segment mid-session, it applies from the next screen visit onwards.
+- Works the same with `react-navigation` and `expo-router`—heatmaps key on route names, and the segment is orthogonal to them.
 
 export default ({ children }) => <DocLayout current="session-replays-heatmaps" previous={{href: '/react-native-guide/mobile-features/people', label: 'People'}} next={{href: '/react-native-guide/mobile-features/custom-events', label: 'Custom Events'}}>{children}</DocLayout>


### PR DESCRIPTION
Documents the new heatmap segmentation feature on the existing **Session Replays & Heatmaps** page (`app/react-native-guide/mobile-features/session-replays-heatmaps/docs.mdx`).

## What's covered
- **Quickstart**: `import { setHeatmapSegment } from 'vexo-analytics'` + `setHeatmapSegment(user.role)`, call after login; `null`/`undefined`/`''` clears (verified against the SDK export surface on `vexo-analytics` main, v1.7.0).
- **Dashboard walkthrough**: the new Segment dropdown next to Version/Model; All = untagged + mixed (today's behavior); per-(screen, version, model, segment) screenshot + tap pool.
- **Limits, documented honestly**: 64-char max (longer ignored with a console warning), 20 distinct segments per app (beyond the cap stored untagged), quota impact (each segment multiplies screenshot volume; free tier 2000), capture timing (first screen visit after the segment is set; mid-session changes apply from the next visit), react-navigation and expo-router both supported.
- Folds the segment dimension into the existing tap-context list and screenshot-dedup paragraph so the rest of the page stays accurate.
- Version note: requires vexo-analytics 1.7.0+.

No nav change needed (existing page; sidebar/search index derive from `layoutData.tsx`, which is unchanged). `next build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)