### PR TITLE
docs: replace legacy tiered pricing with v3 usage-based pricing

### DIFF
--- a/app/settings/account-settings/docs.mdx
+++ b/app/settings/account-settings/docs.mdx
@@ -11,19 +11,11 @@ This is where you can change your name or the e-mail that you've provided.
 
 # Subscription Information
 
-You can review and adjust your plan details:
+The **Subscription Information** section shows your current monthly event usage — broken down by custom, fetch, and navigation events — against the free allowance of **500,000 events per month**.
 
-- **Subscription Interval:** Monthly or annual billing.
-- **Seats:** Number of team members with access.
-- **Events per Month:** Plan limit (e.g., 1M events for $39/mo).
-- **Enable Overage:** When enabled, extra events that go over your plan are billed automatically without pausing tracking.
+Vexo pricing is usage-based, so there is no plan editor: if you're on the free plan, click **Add billing** to enable pay-as-you-go billing beyond the free allowance; once billing is enabled, **Manage billing** opens the Stripe billing portal to update your card, view invoices, or cancel.
 
-> Example: Extra events above your plan limit are charged at $0.076 per 1,000 events.
-> 
-
-To modify your plan, adjust the fields and click **Update Subscription**.
-
-<DocImage src="/docs/subscription-information.png" width="1049" height="620" size="large" />
+See [Subscription](/settings/subscription) for how usage-based pricing works and the full rate table, and [Billing](/settings/billing) for common billing questions.
 
 # Delete Account
 

--- a/app/settings/billing/docs.mdx
+++ b/app/settings/billing/docs.mdx
@@ -6,7 +6,7 @@ Answers to the most common questions about billing, invoices, and payments in Ve
 
 ### How is billing calculated?
 
-Billing is based on your **total event usage across all apps and websites** under your account. You can view your monthly usage anytime in your account settings.
+Billing is **usage-based**: your **total event usage across all apps and websites** under your account, billed monthly **in arrears**. The first **500,000 events each month are free**; beyond that you pay graduated per-million rates — see [Subscription](/settings/subscription) for the full rate table. You can view your monthly usage anytime in your account settings.
 
 ### How do I get my invoices?
 
@@ -18,19 +18,22 @@ If you want invoices sent to a different email, just contact us with your curren
 
 We accept **credit and debit cards**, **Google Pay**, and **Cash Pay**. All payments are securely processed through Stripe. At the moment, we don’t support wire transfers, manual invoicing, or cryptocurrency payments.
 
-### What happens if I exceed my monthly event limit?
+### What happens if I go over the free allowance?
 
-You’ll never be charged unexpectedly. Extra usage is only billed if you’ve enabled **Overages** in your subscription settings. Otherwise, once you reach **120% of your event limit**, Vexo will stop tracking new events until you upgrade your plan.
+On the **free plan**, event collection stops once you reach 500,000 events in a month — the API responds with `406 — Free plan event limit reached. Add billing to keep collecting events.` Session replays continue to upload, and your existing data and dashboards remain fully accessible. Collection resumes at the start of the next month, or immediately once you add billing.
 
-Don’t worry—your existing data and dashboards remain fully accessible while tracking is paused.
+With **billing enabled** there is no account-wide cutoff — you simply pay for what you use. If you want a hard spending ceiling, you can set an optional per-app events cap in your app's settings; when an app reaches its cap, Vexo stops collecting new data for that app until the billing period resets.
+
+Accounts still on a **legacy tiered plan** (before the September 1, 2026 migration) keep their plan's existing limit behavior until they are migrated.
 
 ### How do I update my billing information?
 
 To update your billing details:
 
 1. Log into your Vexo account.
-2. Click your profile name in the top-right corner.
-3. Select **Account Settings → Subscription**.
-4. Click **Update billing info** under the *Next bill amount* section.
+2. Click your profile name in the top-right corner and open **Settings**.
+3. Under **Subscription Information**, click **Manage billing**.
+
+This opens the Stripe billing portal, where you can update your card, view past invoices, or cancel your subscription. If you haven't enabled billing yet, the same section shows **Add billing** instead.
 
 export default ({ children }) => <DocLayout current="billing" previous={{href: '/settings/account-settings', label: 'Account Settings'}} next={{href: '/settings/subscription', label: 'Subscription'}}>{children}</DocLayout>

--- a/app/settings/subscription/docs.mdx
+++ b/app/settings/subscription/docs.mdx
@@ -2,44 +2,51 @@ import { DocLayout } from '../../../components/DocLayout';
 
 # Subscription
 
-Vexo offers simple, transparent plans designed to grow with your app — from early-stage projects to high-traffic products. You can switch plans or adjust event limits anytime right from your account.
+Vexo pricing is **usage-based**: a generous free allowance every month, then you pay only for the events you actually send. There are no plans to pick, no annual contracts, and no overage toggles.
 
-### How Vexo Plans Work
+### How it works
 
-All Vexo plans are based on your **total monthly events** across apps and websites in your account. An event includes both direct and indirect interactions with your app or site — such as taps, clicks, navigations, API calls, errors, and custom events.
+- Every account includes **500,000 events per month, free** — no credit card required.
+- Beyond the free allowance, you pay per million events at graduated rates (see the table below).
+- Usage is billed monthly **in arrears**: at the end of each billing period you are charged for the events you used during it.
+- An event includes both direct and indirect interactions with your app or site — such as taps, clicks, navigations, API calls, errors, and custom events — counted across **all apps and websites** in your account.
 
-You can check your real-time usage anytime in **Account Settings → Subscription**.
+You can check your real-time usage anytime in **Settings**.
 
-### Vexo Plan Tiers
+### Rates
 
-**Free** – For small apps or during development. Perfect to try Vexo out.
+| Monthly events | Rate |
+| --- | --- |
+| First 500,000 | Free |
+| 500K – 10M | $30 per million |
+| 10M – 50M | $22 per million |
+| 50M – 150M | $16 per million |
+| Above 150M | $12 per million |
 
-Includes up to **100k events**, **100 session replays**, **2,000 heatmaps**, and **2 free seats**.
+Rates are graduated, so each rate only applies to the events that fall inside its band. For example, at **2.5M events** in a month, the first 500K are free and the remaining 2M are billed at $30 per million — **$60** for the month.
 
-**Premium - $16/mo annual billing ($19/mo monthly billing)**
+You can estimate your monthly bill with the calculator on the [pricing page](https://www.vexo.co/pricing).
 
-Best for teams launching their next project.
+### Seats
 
-Includes up to **250k events**, **1,000 session replays**, **unlimited heatmaps**, and **2 seats** with full access to all features.
+Your first **3 seats are free**. Additional seats are **$5 per seat per month**.
 
-**Enterprise – $32/mo annual billing ($39/mo monthly billing)**
+### Enabling billing
 
-Ideal for apps with a growing or large user base.
+Free accounts don't need a card. To keep collecting events beyond the free allowance:
 
-Includes up to **1M events**, **4,000 session replays**, **unlimited heatmaps**, **2 seats**, and a **customizable dashboard**.
+1. Log into your Vexo account.
+2. Click your profile name in the top-right corner and open **Settings**.
+3. Under **Subscription Information**, click **Add billing** and complete checkout.
 
-Within the Enterprise plan, you can scale beyond 1M events — pricing adjusts with usage, and you can set your event cap directly in your account.
+Once billing is enabled, the same section shows **Manage billing**, which opens the Stripe billing portal — update your card, view invoices, or cancel anytime. There are no contracts or cancellation fees.
 
-### Going Over Your Monthly Event Limit
+### Reaching the free limit
 
-You’ll never be billed unexpectedly. If **Overages** are enabled, additional events beyond your plan are billed at the specified rate. Otherwise, Vexo stops tracking new events once you reach **120% of your plan limit**, while keeping all your existing stats accessible.
+On the free plan, event collection **stops** once you reach 500,000 events in a month. The API responds with `406 — Free plan event limit reached. Add billing to keep collecting events.` Session replays continue to upload, and all of your existing data and dashboards remain fully accessible. Collection resumes at the start of the next month — or immediately once you add billing.
 
-If higher traffic becomes consistent, you can upgrade seamlessly to the next tier or adjust your Enterprise event cap. Upgrades are **self-serve and prorated**, so you only pay for the remaining period.
+### Existing accounts
 
-### Managing Your Subscription
-
-You can update your plan, switch billing frequency, or cancel anytime in **Account Settings → Subscription**.
-
-There are no contracts, hidden fees, or penalties — just flexible plans designed for growth.
+Usage-based pricing applies to all new accounts today. Accounts still on the earlier tiered plans keep their current plan until they are migrated to usage-based pricing on **September 1, 2026**.
 
 export default ({ children }) => <DocLayout current="subscription" previous={{href: '/settings/billing', label: 'Billing'}} next={{href: '/settings/app-settings/app-general-information', label: 'General Information'}}>{children}</DocLayout>


### PR DESCRIPTION
## What

Updates the three Settings docs pages that still described the pre-acquisition tiered plans. Stale pricing here actively misleads customers mid-migration.

### `/settings/subscription` (rewritten)
Was: Free 100K / Premium $16-19/mo / Enterprise $32-39/mo, annual billing, overages, 120% cutoff.
Now: v3 usage-based pricing — **500K events/mo free**, then graduated rates ($30/M to 10M, $22/M to 50M, $16/M to 150M, $12/M beyond), first **3 seats free** then $5/seat/mo, billed monthly **in arrears**, no annual plans, no overages. Includes the worked $60 @ 2.5M example (matches the pricing-page calculator), the free-limit hard-stop behavior (406 "Free plan event limit reached. Add billing to keep collecting events.", replays still upload), self-serve **Settings → Add billing**, and the **Sep 1, 2026** legacy-plan migration note.

### `/settings/billing` (3 FAQ answers updated)
- "How is billing calculated" → usage-based, in arrears, links to the rate table
- "What happens if I exceed my limit" → free-plan 406 hard stop / no account-wide cutoff with billing enabled / optional per-app caps / legacy-plan note
- "How do I update billing info" → **Settings → Subscription Information → Manage billing** (Stripe portal); old path (Subscription editor → Update billing info) no longer exists

### `/settings/account-settings`
Replaced the "Subscription Information" section describing the removed plan editor (interval / overage toggle / "1M events for $39/mo" / $0.076 per 1,000 overage example) with the current UI (usage breakdown + Add billing / Manage billing). Dropped the stale `subscription-information.png` screenshot of the old editor.

## Verification
- Rates/example verified against vexo-web `Pricing.tsx` (`v3MonthlyPrice`, live Stripe graduated price) and `settings/UpgradeSubscription.tsx` (Add billing / Manage billing copy)
- `npm ci && npx next build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)