### PR TITLE
docs: add Usage & Limits page under Settings

### DIFF
--- a/app/settings/app-settings/app-general-information/docs.mdx
+++ b/app/settings/app-settings/app-general-information/docs.mdx
@@ -9,4 +9,4 @@ Here you are able to change your apps properties, as the name or the icon, as we
 
 <DocImage src="/docs/app-general-info.png" width="1050" height="703" size="large" />
 
-export default ({ children }) => <DocLayout current="app-general-information" previous={{href: '/settings/subscription', label: 'Subscription'}} next={{href: '/settings/app-settings/webhooks', label: 'Webhooks'}}>{children}</DocLayout>
+export default ({ children }) => <DocLayout current="app-general-information" previous={{href: '/settings/usage-limits', label: 'Usage & Limits'}} next={{href: '/settings/app-settings/webhooks', label: 'Webhooks'}}>{children}</DocLayout>

--- a/app/settings/subscription/docs.mdx
+++ b/app/settings/subscription/docs.mdx
@@ -49,4 +49,4 @@ On the free plan, event collection **stops** once you reach 500,000 events in a 
 
 Usage-based pricing applies to all new accounts today. Accounts still on the earlier tiered plans keep their current plan until they are migrated to usage-based pricing on **September 1, 2026**.
 
-export default ({ children }) => <DocLayout current="subscription" previous={{href: '/settings/billing', label: 'Billing'}} next={{href: '/settings/app-settings/app-general-information', label: 'General Information'}}>{children}</DocLayout>
+export default ({ children }) => <DocLayout current="subscription" previous={{href: '/settings/billing', label: 'Billing'}} next={{href: '/settings/usage-limits', label: 'Usage & Limits'}}>{children}</DocLayout>

--- a/app/settings/usage-limits/docs.mdx
+++ b/app/settings/usage-limits/docs.mdx
@@ -1,0 +1,55 @@
+import { DocLayout } from '../../../components/DocLayout';
+
+# Usage & Limits
+
+Every limit in Vexo on one page: what's included, what happens when you reach a cap, and how to resolve dropped events.
+
+### Free plan allowance
+
+Every account includes **500,000 events per month, free**. On the free plan this is a hard limit: once you reach it, event collection stops and the API responds with
+
+```
+406 — Free plan event limit reached. Add billing to keep collecting events.
+```
+
+Session replays continue to upload, and all of your existing data and dashboards remain fully accessible. Collection resumes at the start of the next month — or immediately once you add billing (**Settings → Subscription Information → Add billing**). See [Subscription](/settings/subscription) for rates beyond the free allowance.
+
+### Per-app usage caps
+
+With billing enabled there is no account-wide cutoff — you pay for what you use. To avoid bill-shock, you can set optional **hard caps per billing period** for each app, separately for **events** and **session replays**, under your app's **Settings → Usage limits**.
+
+When an app reaches a cap, Vexo stops collecting new data of that kind for that app until the billing period resets. Already-collected data is never affected. Leave a cap empty for no limit; raise or remove it anytime to resume collection immediately.
+
+### Legacy plans
+
+Accounts still on the earlier tiered plans (until the **September 1, 2026** migration) stop collecting events at their plan's event limit when overages are disabled.
+
+### Dropped events
+
+If events were dropped recently, your app's dashboard shows a banner with the count of events dropped in the last 30 days and the reasons:
+
+- **Invalid events** — the event was malformed and rejected at ingestion, most commonly a custom-event payload over the size limit (see below). Fix the SDK call that produces it.
+- **Over free limit** — your account hit the 500,000 free monthly allowance. Add billing, or wait for the monthly reset.
+- **Over events cap** — the app hit its per-app events cap. Raise or remove the cap under the app's **Settings → Usage limits**.
+- **Account limit** — a legacy plan's event limit was reached. Enable usage-based billing to remove it.
+
+### Custom event limits
+
+- Every custom event needs a **name**; it can be any string.
+- The optional **args payload can be up to 65,536 characters** when serialized. Larger payloads are dropped as invalid events.
+- Custom events sent while no route/screen is known are accepted — they are attributed to the route `unknown`.
+
+### Heatmap limits
+
+- The free plan includes a quota of **2,000 heatmaps**; paid accounts have unlimited heatmaps.
+- [Heatmap segment](/react-native-guide/mobile-features/session-replays-heatmaps) values are limited to **64 characters**, and an app can have up to **20 distinct segment values** — activity beyond that is stored untagged. Each segment multiplies screenshot volume against the heatmap quota, so prefer a few coarse segments.
+
+### Seats
+
+Your first **3 seats are free**; additional seats are **$5 per seat per month**.
+
+### Export API
+
+The [Export API](/settings/app-settings/export-api) has its own request rate limits, documented on its page.
+
+export default ({ children }) => <DocLayout current="usage-limits" previous={{href: '/settings/subscription', label: 'Subscription'}} next={{href: '/settings/app-settings/app-general-information', label: 'General Information'}}>{children}</DocLayout>

--- a/app/settings/usage-limits/page.tsx
+++ b/app/settings/usage-limits/page.tsx
@@ -1,0 +1,10 @@
+import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'Usage & Limits | Vexo Documentation',
+}
+
+export default function Home() {
+    return <Docs />
+}

--- a/components/layoutData.tsx
+++ b/components/layoutData.tsx
@@ -122,6 +122,7 @@ export const sidebarData: SidebarData = [
             { title: 'Account Settings', name: 'account-settings', href: '/settings/account-settings' },
             { title: 'Billing', name: 'billing', href: '/settings/billing' },
             { title: 'Subscription', name: 'subscription', href: '/settings/subscription' },
+            { title: 'Usage & Limits', name: 'usage-limits', href: '/settings/usage-limits' },
             {
                 name: 'app-settings',
                 title: 'App Settings',


### PR DESCRIPTION
**Stacked on #58** — merge #58 first, then retarget/merge this (base is `docs/pricing-v3`).

## What

New page `/settings/usage-limits` (sidebar: Settings → Usage & Limits, between Subscription and App Settings; search index picks it up automatically from `layoutData.tsx`). One page for every limit in the product:

- **Free plan allowance** — 500K events/mo hard stop with the exact API response (`406 — Free plan event limit reached. Add billing to keep collecting events.`), replays still upload, dashboards stay accessible, how collection resumes
- **Per-app usage caps** — the optional per-app events/session-replays hard caps (app Settings → Usage limits), stop-and-resume behavior (matches vexo-web `UsageLimits.tsx`)
- **Legacy plans** — plan-limit stop until the Sep 1, 2026 migration
- **Dropped events** — the dashboard banner and how to resolve each reason (invalid events / over free limit / over events cap / account limit)
- **Custom event limits** — args payload up to 65,536 chars (larger dropped as invalid), empty-route events attributed to `unknown`
- **Heatmap limits** — 2,000 heatmap quota on free, segment value/count caps, cross-link to the new Segments docs (#57)
- **Seats** — first 3 free, then $5/seat/mo
- Pointer to Export API rate limits

Deliberately does not touch the custom-events pages to avoid conflicting with open PR #53 (which appends to the same spot); a one-line cross-ref there can follow once #53 is decided.

## Verification
- `npx next build` passes; `/settings/usage-limits` renders as a static route
- prev/next chain rewired: Subscription → Usage & Limits → General Information

🤖 Generated with [Claude Code](https://claude.com/claude-code)