### PR TITLE
docs: add Data Retention page under Settings

### DIFF
--- a/app/settings/app-settings/app-general-information/docs.mdx
+++ b/app/settings/app-settings/app-general-information/docs.mdx
@@ -9,4 +9,4 @@ Here you are able to change your apps properties, as the name or the icon, as we
 
 <DocImage src="/docs/app-general-info.png" width="1050" height="703" size="large" />
 
-export default ({ children }) => <DocLayout current="app-general-information" previous={{href: '/settings/usage-limits', label: 'Usage & Limits'}} next={{href: '/settings/app-settings/webhooks', label: 'Webhooks'}}>{children}</DocLayout>
+export default ({ children }) => <DocLayout current="app-general-information" previous={{href: '/settings/data-retention', label: 'Data Retention'}} next={{href: '/settings/app-settings/webhooks', label: 'Webhooks'}}>{children}</DocLayout>

--- a/app/settings/data-retention/docs.mdx
+++ b/app/settings/data-retention/docs.mdx
@@ -1,0 +1,28 @@
+import { DocLayout } from '../../../components/DocLayout';
+
+# Data Retention
+
+How long Vexo keeps your data. This policy takes effect on **November 1, 2026** — we're announcing it ahead of time so you can plan.
+
+### Retention windows
+
+| Data | Free plan | Paid |
+| --- | --- | --- |
+| Sessions, session replays & events | 60 days | 24 months |
+| Aggregated metrics (dashboard charts) | 13 months | 24 months |
+
+On the free plan, raw data — individual sessions, session replays, and events — is kept for **60 days**, while the aggregated metrics that power your dashboards are kept for **13 months**, so your charts outlive the raw events behind them. With billing enabled, **everything is kept for 24 months**.
+
+### Extended retention
+
+Need more history? Paid accounts can extend retention to **3, 4, or 5 years total** with the extended-retention add-on:
+
+- Each extra year beyond the 24-month base adds **10% of your average monthly bill** (minimum $1 per year), shown as a monthly add-on price when you select an option.
+- Manage it under **Settings → Data Retention**: pick a total retention length and confirm. The 24-month base is always included.
+- The add-on becomes available on **November 1, 2026**, alongside the policy itself.
+
+### Where to manage it
+
+Your account's retention windows — and the extended-retention options — live in **Settings → Data Retention**. Retention applies account-wide, across all of your apps and websites.
+
+export default ({ children }) => <DocLayout current="data-retention" previous={{href: '/settings/usage-limits', label: 'Usage & Limits'}} next={{href: '/settings/app-settings/app-general-information', label: 'General Information'}}>{children}</DocLayout>

--- a/app/settings/data-retention/page.tsx
+++ b/app/settings/data-retention/page.tsx
@@ -1,0 +1,10 @@
+import Docs from './docs.mdx'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'Data Retention | Vexo Documentation',
+}
+
+export default function Home() {
+    return <Docs />
+}

--- a/app/settings/usage-limits/docs.mdx
+++ b/app/settings/usage-limits/docs.mdx
@@ -52,4 +52,4 @@ Your first **3 seats are free**; additional seats are **$5 per seat per month**.
 
 The [Export API](/settings/app-settings/export-api) has its own request rate limits, documented on its page.
 
-export default ({ children }) => <DocLayout current="usage-limits" previous={{href: '/settings/subscription', label: 'Subscription'}} next={{href: '/settings/app-settings/app-general-information', label: 'General Information'}}>{children}</DocLayout>
+export default ({ children }) => <DocLayout current="usage-limits" previous={{href: '/settings/subscription', label: 'Subscription'}} next={{href: '/settings/data-retention', label: 'Data Retention'}}>{children}</DocLayout>

--- a/components/layoutData.tsx
+++ b/components/layoutData.tsx
@@ -123,6 +123,7 @@ export const sidebarData: SidebarData = [
             { title: 'Billing', name: 'billing', href: '/settings/billing' },
             { title: 'Subscription', name: 'subscription', href: '/settings/subscription' },
             { title: 'Usage & Limits', name: 'usage-limits', href: '/settings/usage-limits' },
+            { title: 'Data Retention', name: 'data-retention', href: '/settings/data-retention' },
             {
                 name: 'app-settings',
                 title: 'App Settings',


### PR DESCRIPTION
**Stacked on #59** (which is stacked on #58) — merge order #58 → #59 → this. Base is `docs/usage-limits`.

## What

New page `/settings/data-retention` (sidebar: Settings → Data Retention; search index derives from `layoutData.tsx` automatically). Documents the retention policy effective **November 1, 2026**, announced ahead of time:

| Data | Free | Paid |
| --- | --- | --- |
| Sessions, replays & events | 60 days | 24 months |
| Aggregated metrics | 13 months | 24 months |

Plus the **extended-retention add-on** (3/4/5 years total, +10% of average monthly bill per extra year, min $1/yr, available Nov 1, 2026) and where to manage it (**Settings → Data Retention**).

No better existing home: the Billing page is a payments FAQ and the dashboard "Retention" page is the user-retention widget (different concept), so this gets its own page — mirroring the dedicated Data Retention card in the product's settings.

## Verification
- Copy matches vexo-web `settings/DataRetention.tsx` and the public pricing page's retention section (60 days / 24 months / 3-4-5 years / from 1 Nov 2026)
- `npx next build` passes; `/settings/data-retention` renders as a static route
- Chain: Usage & Limits → Data Retention → General Information

🤖 Generated with [Claude Code](https://claude.com/claude-code)