### PR TITLE
docs: add Development & staging section to the React Native integration guide

### DIFF
--- a/app/react-native-guide/integration/docs.mdx
+++ b/app/react-native-guide/integration/docs.mdx
@@ -45,6 +45,36 @@ export default function RootLayout() {
 
 **Wait, that's it?** Yes! That's it. With that ease of integration experience you get an incredible set of features, go [check them out](/react-native-guide/mobile-features/overview)!
 
+## Development & staging
+
+You usually don't want your own development sessions mixed into your production analytics.
+Vexo only starts when you call `vexo(...)` — nothing is collected or sent before that — so the
+recommended way to disable it is to simply make the call conditional:
+
+```js
+import { vexo } from 'vexo-analytics';
+
+if (!__DEV__) {
+  vexo('YOUR_API_KEY');
+}
+```
+
+A few things you can rely on when Vexo has not been initialized:
+
+- Not calling `vexo()` is a fully supported way to disable Vexo. There is no background work,
+  and no data leaves the device.
+- `customEvent()` calls are safely ignored: the event is dropped and a warning is logged to the
+  console. Your app's behavior is not affected, so you don't need to guard every call site.
+- `identifyDevice()`, `enableTracking()` and `disableTracking()` are safe no-ops as well.
+
+If you'd rather keep development or staging data instead of dropping it, create a separate app
+in your [dashboard](https://www.vexo.co) (for example "MyApp — Staging") and pick the API key
+by environment:
+
+```js
+vexo(__DEV__ ? 'STAGING_API_KEY' : 'PRODUCTION_API_KEY');
+```
+
 ## How it works
 
 **One line of code? How is this possible?**


### PR DESCRIPTION
## Why

Issue #17 asks how to properly disable Vexo in development, whether skipping `vexo()` is safe, and what `customEvent()` does when Vexo was never initialized. The docs currently only hint at this in a one-line code comment in the quick-start snippet.

## What

Adds a short **Development & staging** section to `app/react-native-guide/integration/docs.mdx` (right after the Quickstart) covering:

- conditional init: `if (!__DEV__) { vexo('YOUR_API_KEY'); }` — the recommended pattern (same guidance as the SDK README)
- the guarantee that nothing is collected or sent before `vexo()` is called
- `customEvent()` pre-init behavior: safely ignored with a console warning (verified in the SDK: `src/vexo/engine/user/eventCreator.js`), `identifyDevice()`/`enableTracking()`/`disableTracking()` are safe no-ops too (`src/vexo/engine/device/apiClient.js` bails without a synced API key)
- the separate-staging-app pattern for teams that want dev data kept but separated

No sidebar change needed (existing route, new heading only). `npm ci && next build` passes.

Closes #17 (vexotech/docs#17) once merged — reply drafted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)