### PR TITLE
Fix 404s and add redirects to preserve link equity

### DIFF
--- a/app/docs.mdx
+++ b/app/docs.mdx
@@ -35,6 +35,6 @@ vexo('YOUR_API_KEY');
 5. Re-build and run your app (the `vexo-analytics` package includes native code).
 6. Go to your app's page on Vexo and you should see your first event!
 
-**Wait, that's it?** Yes! That's it. With that ease of integration experience you get an incredible set of features, go [check them out](https://docs.vexo.co/features)!
+**Wait, that's it?** Yes! That's it. With that ease of integration experience you get an incredible set of features, go [check them out](/react-native-guide/mobile-features/overview)!
 
-export default ({ children }) => <DocLayout current="integration" next={{href: 'features', label: 'Supported features'}}>{children}</DocLayout>
+export default ({ children }) => <DocLayout current="integration" next={{href: '/react-native-guide/mobile-features/overview', label: 'Supported features'}}>{children}</DocLayout>

--- a/next.config.js
+++ b/next.config.js
@@ -11,5 +11,64 @@ module.exports = withMDX({
     pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
     experimental: {
         appDir: true,
-    }
+    },
+    async redirects() {
+        return [
+            {
+                source: '/features',
+                destination: '/react-native-guide/mobile-features/overview',
+                permanent: true,
+            },
+            {
+                source: '/docs',
+                destination: '/get-started/introduction',
+                permanent: true,
+            },
+            {
+                source: '/guide',
+                destination: '/get-started/introduction',
+                permanent: true,
+            },
+            {
+                source: '/getting-started',
+                destination: '/get-started/introduction',
+                permanent: true,
+            },
+            {
+                source: '/introduction',
+                destination: '/get-started/introduction',
+                permanent: true,
+            },
+            {
+                source: '/quickstart',
+                destination: '/get-started/quick-start',
+                permanent: true,
+            },
+            {
+                source: '/mobile',
+                destination: '/react-native-guide/introduction',
+                permanent: true,
+            },
+            {
+                source: '/web',
+                destination: '/web-guide/introduction',
+                permanent: true,
+            },
+            {
+                source: '/sdk',
+                destination: '/get-started/quick-start',
+                permanent: true,
+            },
+            {
+                source: '/integration',
+                destination: '/react-native-guide/integration',
+                permanent: true,
+            },
+            {
+                source: '/install',
+                destination: '/get-started/quick-start',
+                permanent: true,
+            },
+        ];
+    },
 })


### PR DESCRIPTION
Supersedes #54 (drops the duplicated vercel.json — next.config.js is the single source of truth); original by @felikala.

- 11 permanent redirects for legacy URL shapes (`/features`, `/docs`, `/quickstart`, …) in `next.config.js`
- Fixes the dead `/features` link and DocLayout next-href in `app/docs.mdx`
- All redirect destinations verified to exist as app-router routes; no source collides with an existing route
- `npm ci && next build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)