### PR TITLE
Add 404 page, dynamic sitemap, and robots.txt

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+import { ChartPieIcon } from '@heroicons/react/outline';
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-white">
+      <header className="p-6">
+        <Link href="/" className="inline-flex items-center gap-2 text-slate-700">
+          <ChartPieIcon className="w-4 text-indigo-500" />
+          <span><b>Vexo</b> Analytics</span>
+        </Link>
+      </header>
+
+      <main className="flex flex-col items-center justify-center px-6 py-32">
+        <p className="text-base font-medium text-indigo-500">404</p>
+        <h1 className="mt-4 text-4xl font-medium tracking-tight text-slate-900 sm:text-5xl">
+          Page not found
+        </h1>
+        <p className="mt-4 text-base text-slate-600">
+          Sorry, we couldn&apos;t find the page you&apos;re looking for.
+        </p>
+        <Link
+          href="/"
+          className="mt-8 rounded-full bg-indigo-500 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-600"
+        >
+          Back to home
+        </Link>
+      </main>
+    </div>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,29 @@
+import fs from 'fs'
+import path from 'path'
+import type { MetadataRoute } from 'next'
+
+const BASE_URL = 'https://docs.vexo.co'
+const PAGE_FILES = ['page.tsx', 'page.ts', 'page.jsx', 'page.js']
+
+// Walks app/ at build time, so the sitemap always matches the deployed routes.
+// ponytail: skips route groups and dynamic segments — this repo has neither;
+// revisit if app/(group)/ or app/[param]/ dirs ever appear.
+function routesUnder(dir: string, route: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  const routes: string[] = []
+  if (entries.some((e) => e.isFile() && PAGE_FILES.includes(e.name))) {
+    routes.push(route || '/')
+  }
+  for (const e of entries) {
+    if (!e.isDirectory()) continue
+    if (/^[_([]/.test(e.name)) continue
+    routes.push(...routesUnder(path.join(dir, e.name), `${route}/${e.name}`))
+  }
+  return routes
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return routesUnder(path.join(process.cwd(), 'app'), '')
+    .sort()
+    .map((route) => ({ url: `${BASE_URL}${route}` }))
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.vexo.co/sitemap.xml


### PR DESCRIPTION
Supersedes #55; original by @felikala; sitemap now generated/current + robots.txt added.

- `app/not-found.tsx`: the 404 page from #55, taken unchanged (matches vexo-web's design, heroicons v1 `/outline` imports as used elsewhere in this repo)
- `app/sitemap.ts`: replaces #55's static `public/sitemap.xml`, which was already stale — missing 5 routes added since March (RN dashboard errors/network-stats/retention, web dashboard errors/network-stats) plus the homepage. The sitemap is now generated from the `app/` route tree at build time (Next 13.4 metadata route), so it can never drift from the deployed routes. Currently emits 58 URLs, verified in the build output.
- `public/robots.txt`: `Sitemap: https://docs.vexo.co/sitemap.xml`
- `npm ci && next build` green; `/sitemap.xml` and `/_not-found` both present as static routes in the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)