### PR TITLE
[hold for 1.9.0] docs: integration requirements + changelog for SDK 1.9.0

### DIFF
--- a/app/changelog/docs.mdx
+++ b/app/changelog/docs.mdx
@@ -3,6 +3,23 @@ import Link from 'next/link'
 
 # Changelog
 
+{/* Set the real release date below when 1.9.0 is published to npm. */}
+
+## 1.9.0 (unreleased)
+
+### Features
+
+* New Architecture support — the native module runs as a TurboModule, and old-architecture apps keep working unchanged
+* `VexoProvider` — explicitly wrap your navigation container when automatic attachment isn't possible
+
+### Changed
+
+* iOS minimum deployment target raised from 11.0 to 15.1 (the React Native 0.76+ default)
+* `@react-navigation/native` is now an optional peer dependency — Expo Router apps don't need to install anything extra
+* Modern packaging: CommonJS + ESM builds behind an `exports` map. Deep imports like `vexo-analytics/lib/dist/...` no longer resolve — import from the public entry points instead
+* Faster startup: the SDK no longer does any work at import time, and events are uploaded in batches
+* Trimmed vendored internals and releases published via npm Trusted Publishing with provenance attestation
+
 ## 1.8.0 (2026-08-14)
 
 ### Features

--- a/app/react-native-guide/integration/docs.mdx
+++ b/app/react-native-guide/integration/docs.mdx
@@ -9,9 +9,11 @@ Our documentation is a great place to find most answers and make sure that your 
 
 ## Quickstart
 
-**Prerequisites**
+**Requirements**
 
-- Using [React Navigation](https://reactnavigation.org/) or [Expo Router](https://docs.expo.dev/router/introduction/)
+- iOS 15.1 or later as your app's minimum deployment target (the default on React Native 0.76+)
+- Using [React Navigation](https://reactnavigation.org/) or [Expo Router](https://docs.expo.dev/router/introduction/). `@react-navigation/native` is an optional peer dependency — Expo Router apps don't need to install anything extra, and React Navigation apps keep working unchanged
+- Both React Native architectures are supported: on the New Architecture the native module runs as a TurboModule, and the old architecture keeps working as before
 
 **Expo**
 
@@ -39,6 +41,8 @@ export default function RootLayout() {
 ```
 
 > ⚠️ **Important**: Initialize Vexo at the module level, not inside `useEffect` or component functions, to ensure proper tracking from app start.
+
+> ℹ️ **Imports**: since SDK 1.9.0 the package ships modern CommonJS and ESM builds behind an `exports` map. Always import from the public entry points (like `vexo-analytics` above) — deep imports such as `vexo-analytics/lib/dist/...` no longer resolve.
 
 5. Re-build and run your app (the `vexo-analytics` package includes native code).
 6. Go to your app's page on Vexo and you should see your first event!


### PR DESCRIPTION
**DO NOT MERGE until vexo-analytics v1.9.0 is published.**

Stacked on #64. Documents what only becomes true at 1.9.0 (verified against vexotech/vexo-analytics main, PRs #87–#91):

## Integration page (`/react-native-guide/integration`)

- Prerequisites → **Requirements**: iOS minimum deployment target **15.1** (was 11.0; RN 0.76+ default).
- **New Architecture supported** — TurboModule spec; old-architecture apps keep working unchanged (the module is served via interop there).
- `@react-navigation/native` peer is now **optional** (`peerDependenciesMeta`): Expo Router apps need nothing extra, React Navigation apps unchanged.
- Breaking-ish packaging note: CJS + ESM behind an `exports` map — deep imports like `vexo-analytics/lib/dist/...` no longer resolve; use the public entry points. (No page in these docs used deep imports, so this is only an advisory note.)

## Changelog page

- **1.9.0 (unreleased)** entry: New Arch support, `VexoProvider` explicit wrap, iOS 11.0 → 15.1, optional react-navigation peer, exports-map packaging with the deep-import migration note, no import-time work + batched event uploads, trimmed vendored internals, Trusted-Publishing/provenance-attested releases.
- The date is a placeholder (`unreleased` + an MDX comment) — set it when the npm release goes out. Note: 1.7.0/1.8.0 were published *without* provenance attestations, so the provenance claim genuinely starts at 1.9.0; if the 1.9.0 publish ends up without provenance, drop that half-bullet before merging.

`npm ci && next build` passes on this branch (64/64 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)