### PR TITLE
docs(pricing): v3 session-replay model — 1,000 included/cycle, $3 per 1,000, user-set replay limit

### DIFF
--- a/app/settings/billing/docs.mdx
+++ b/app/settings/billing/docs.mdx
@@ -6,7 +6,7 @@ Answers to the most common questions about billing, invoices, and payments in Ve
 
 ### How is billing calculated?
 
-Billing is **usage-based**: your **total event usage across all apps and websites** under your account, billed monthly **in arrears**. The first **500,000 events each month are free**; beyond that you pay graduated per-million rates — see [Subscription](/settings/subscription) for the full rate table. You can view your monthly usage anytime in your account settings.
+Billing is **usage-based**: your **total event usage across all apps and websites** under your account, billed monthly **in arrears**. The first **500,000 events each month are free**; beyond that you pay graduated per-million rates — see [Subscription](/settings/subscription) for the full rate table. Session replays are billed the same way, separately from events: **1,000 replays per cycle are included free**, then **$3 per 1,000** up to the replay limit you set in Settings. You can view your monthly usage anytime in your account settings.
 
 ### How do I get my invoices?
 
@@ -20,7 +20,7 @@ We accept **credit and debit cards**, **Google Pay**, and **Cash Pay**. All paym
 
 ### What happens if I go over the free allowance?
 
-On the **free plan**, event collection stops once you reach 500,000 events in a month — the API responds with `406 — Free plan event limit reached. Add billing to keep collecting events.` Session replays continue to upload, and your existing data and dashboards remain fully accessible. Collection resumes at the start of the next month, or immediately once you add billing.
+On the **free plan**, event collection stops once you reach 500,000 events in a month — the API responds with `406 — Free plan event limit reached. Add billing to keep collecting events.` Session replays continue to upload (they have their own allowance of 1,000 per cycle — see [Subscription](/settings/subscription)), and your existing data and dashboards remain fully accessible. Collection resumes at the start of the next month, or immediately once you add billing.
 
 With **billing enabled** there is no account-wide cutoff — you simply pay for what you use. If you want a hard spending ceiling, you can set an optional per-app events cap in your app's settings; when an app reaches its cap, Vexo stops collecting new data for that app until the billing period resets.
 

--- a/app/settings/subscription/docs.mdx
+++ b/app/settings/subscription/docs.mdx
@@ -31,6 +31,15 @@ You can estimate your monthly bill with the calculator on the [pricing page](htt
 
 Your first **3 seats are free**. Additional seats are **$5 per seat per month**.
 
+### Session replays
+
+Session replays are priced separately from events, with the same shape: a flat free allowance, then pay-as-you-go.
+
+- Every account includes **1,000 session replays per billing cycle, free** — counted across all apps and websites in your account.
+- Beyond the included 1,000, replays are **$3 per 1,000** (that's $0.003 per replay), billed monthly in arrears alongside your event usage. Pay-as-you-go replays require billing to be enabled.
+- Your account has a **replay limit** — a hard cap on replays recorded per cycle, which you control in **Settings → Session Replays**. It defaults to 1,000. Raising it above 1,000 is how you opt in to pay-as-you-go replays; you can also lower it (even to 0) at any time for privacy or cost control. Free accounts can set it up to 1,000.
+- When you reach your replay limit, new session replays **pause** until the next cycle starts or you raise the limit. Events, dashboards, and existing replays are unaffected.
+
 ### Enabling billing
 
 Free accounts don't need a card. To keep collecting events beyond the free allowance:


### PR DESCRIPTION
## What

Documents the v3 session-replay pricing model alongside the existing usage-based events pricing:

- `app/settings/subscription/docs.mdx`: new "Session replays" section — 1,000 replays included free per billing cycle (all apps/sites), $3 per 1,000 beyond that billed monthly in arrears, and the Settings → Session Replays hard-limit knob (default 1,000; raising above 1,000 opts in to pay-as-you-go; lowering — even to 0 — always allowed; free accounts capped at 1,000; replays pause at the limit until the next cycle).
- `app/settings/billing/docs.mdx`: the "How is billing calculated?" answer now covers replays; the free-allowance answer clarifies replays have their own separate allowance and links to Subscription.

Pairs with vexo-api / vexo-web `feat/v3-replay-payg`.

## Testing

```
yarn build (next build) — compiles clean, all pages render statically.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
