### PR TITLE
docs: reconcile pricing/limits/replay claims to code + add SDK API coverage

### DIFF
--- a/app/react-native-guide/integration/docs.mdx
+++ b/app/react-native-guide/integration/docs.mdx
@@ -83,6 +83,8 @@ It's very simple! Vexo is a very lightweight advanced piece of technology that l
 packs the data into a buffer and sends it to our servers.
 Given that it works in background with your app, there are no code dependencies and it's effortless to integrate!
 
+Events are **batched** before they leave the device: the SDK sends a group as soon as it has **20 events**, or **5 seconds** after the first event was queued — whichever comes first. This keeps network and battery usage low without you having to think about it.
+
 ### Events
 
 Supported events are:
@@ -94,6 +96,8 @@ Supported events are:
 - Your app sent a request for data
 - An error occurred
 - Custom events
+
+Every one of these — taps, screen changes, requests, errors and your custom events — counts toward your account's monthly event total. See [Subscription](/settings/subscription) for the **500,000 events per month** free allowance and the pay-as-you-go rates beyond it.
 
 ### Device Identity
 
@@ -147,6 +151,26 @@ await disableTracking();
 await enableTracking();
 ```
 
+### Error reporting
+
+Errors that reach the top of your app are captured automatically. To report a caught exception yourself — without crashing the app — call `trackError`:
+
+```js
+import { trackError } from 'vexo-analytics'
+
+try {
+  await riskyOperation();
+} catch (err) {
+  trackError(err);
+}
+```
+
+By default the error is recorded as **handled**, so it does not count against your crash-free rate. Pass `{ handled: false }` to record it as an unhandled error instead:
+
+```js
+trackError(err, { handled: false });
+```
+
 ### Custom events
 
 This is where the power of out of the box analytics meets the custom needs of your business.
@@ -172,5 +196,13 @@ We will understand the context about the event that has just happened and infer 
 - ... and more!
 
 For further understanding on custom events check out [the docs](/react-native-guide/mobile-features/custom-events)
+
+## Troubleshooting
+
+### Scroll feels laggy after returning from the background
+
+Some apps saw a brief scroll stutter the first time a list is scrolled after the app comes back from the background to the foreground. This is fixed in `vexo-analytics` **1.8.0 and later**, so upgrading the SDK resolves it for most apps.
+
+If you still see it and don't need session replay, you can turn replay off for the app from your [dashboard](https://www.vexo.co) tracking settings. A code-level switch — `vexo('YOUR_API_KEY', { sessionReplay: false })` — is targeted for the next release (**v1.9.1**) and is not available yet. See docs issue #49 for background and `vexo-analytics` PR #95 for the upcoming option.
 
 export default ({ children }) => <DocLayout current="rn-integration" previous={{href: '/react-native-guide/introduction', label: 'Introduction'}} next={{href: '/react-native-guide/store-compliance', label: 'App Store & Play Compliance'}}>{children}</DocLayout>

--- a/app/react-native-guide/mobile-features/dashboard/customize-dashboard/docs.mdx
+++ b/app/react-native-guide/mobile-features/dashboard/customize-dashboard/docs.mdx
@@ -4,12 +4,12 @@ import Link from 'next/link'
 
 # Customize your dashboard
 
-<Warning message={(<div>This feature is for <b>premium & enterprise</b> accounts only</div>)} />
+<Warning message={(<div>The free plan includes up to <b>3 custom widgets</b>. This limit is tied to your monthly event volume — accounts under 250K events/month get the free limit of 3 — not to a specific plan name.</div>)} />
 
 ### How it works
 
 Tracking custom events is a great way to gain insight into key business metrics. To make it easier
-to track each custom events we allow our enterprise users to add custom widgets to their dashboard, this
+to track each custom event we let you add custom widgets to your dashboard, this
 custom widgets shows the daily events of a selected custom events filtered by any property attached to it.
 
 Additionally, custom widgets support the same global filters as the rest of the dashboard so all the information

--- a/app/react-native-guide/mobile-features/dashboard/funnels/docs.mdx
+++ b/app/react-native-guide/mobile-features/dashboard/funnels/docs.mdx
@@ -1,10 +1,8 @@
-import { DocLayout, DocImage, Warning } from '../../../../../components';
+import { DocLayout, DocImage } from '../../../../../components';
 import Image from 'next/image'
 import Link from 'next/link'
 
 # Funnels
-
-<Warning message={(<div>This feature is for <b>premium & enterprise</b> accounts only</div>)} />
 
 Funnels help you track how users move through a sequence of actions in your app.
 You can use them to see where users drop off and where they continue,

--- a/app/react-native-guide/mobile-features/dashboard/network-stats/docs.mdx
+++ b/app/react-native-guide/mobile-features/dashboard/network-stats/docs.mdx
@@ -15,6 +15,15 @@ Every time a user's device makes a network request, Vexo captures the route (URL
 
 <DocImage src="/docs/network-widget.png" size="small" />
 
+## What's captured
+
+Vexo records your app's outbound HTTP requests. Two kinds of traffic are excluded so they don't clutter your data:
+
+- **Vexo's own analytics requests**, matched by their host, so the SDK never reports on itself.
+- **React Native dev-server noise** — the `/symbolicate` and `/logs` endpoints, matched as exact paths.
+
+Because the dev-server filter is anchored to those exact paths, your own requests to URLs that merely contain those words (for example `/api/logs` or `/v1/symbolicate-batch`) are still captured normally.
+
 ## Sorting
 
 You can sort the network stats by different criteria using the dropdown at the top of the widget:

--- a/app/react-native-guide/mobile-settings/docs.mdx
+++ b/app/react-native-guide/mobile-settings/docs.mdx
@@ -17,11 +17,11 @@ When this option is checked, session replays will be blurred.
 
 ### Send replays only on wifi
 
-When this option is checked, devices will only send session replays over will.
+When this option is checked, devices will only send session replays over wifi.
 
 ### Limit replays duration
 
-When this option is checked, all new session replays will be limited to 5min.
+When this option is checked, new session replays are capped in length. The cap defaults to **5 minutes**; raising it (up to **15 minutes**) requires a paid plan.
 
 ### Include fetch events
 
@@ -29,7 +29,7 @@ When this option is unchecked, all your devices fetch events will be ignored by 
 
 ### Tap sampling events
 
-Only enabled for paid accounts, we allow to sample tap events based on the given percentage.
+Sample tap events based on a percentage you choose. Available on all plans.
 
 <DocImage src="/docs/mobile-app-tracking.png" width="1050" height="703" size="large" />
 

--- a/app/settings/app-settings/export-api/docs.mdx
+++ b/app/settings/app-settings/export-api/docs.mdx
@@ -241,9 +241,9 @@ curl --location --request GET 'https://api.vexo.co/external/apps/your-app-id/eve
 --header 'Authorization: {AUTH_TOKEN}'
 ```
 
-## Rate Limits
+## Limits
 
-- Maximum 5 requests per application per minute
+- Requests may be rate limited to keep the service healthy, so keep polling to a reasonable frequency and handle `429` responses by backing off and retrying.
 - Maximum 10,000 events per request (default is max)
 - Authentication tokens work the same as normal login behavior
 

--- a/app/settings/billing/docs.mdx
+++ b/app/settings/billing/docs.mdx
@@ -16,7 +16,7 @@ If you want invoices sent to a different email, just contact us with your curren
 
 ### What payment methods do you support?
 
-We accept **credit and debit cards**, **Google Pay**, and **Cash Pay**. All payments are securely processed through Stripe. At the moment, we don’t support wire transfers, manual invoicing, or cryptocurrency payments.
+All payments are securely processed through **Stripe**, and the methods offered at checkout are managed there — they currently include **credit and debit cards**, **Google Pay**, and **Cash App Pay**, and the exact options can vary by region and device. We don’t support wire transfers, manual invoicing, or cryptocurrency payments.
 
 ### What happens if I go over the free allowance?
 

--- a/app/settings/subscription/docs.mdx
+++ b/app/settings/subscription/docs.mdx
@@ -29,7 +29,7 @@ You can estimate your monthly bill with the calculator on the [pricing page](htt
 
 ### Seats
 
-Your first **3 seats are free**. Additional seats are **$5 per seat per month**.
+Your first **2 seats are free**. Additional seats are **$5 per seat per month**.
 
 ### Session replays
 

--- a/app/web-guide/web-features/dashboard/customize-dashboard/docs.mdx
+++ b/app/web-guide/web-features/dashboard/customize-dashboard/docs.mdx
@@ -2,11 +2,11 @@ import { DocLayout, Warning } from '../../../../../components';
 
 # Customize your dashboard
 
-<Warning message={(<div>This feature is for <b>premium & enterprise</b> accounts only</div>)} />
+<Warning message={(<div>The free plan includes up to <b>3 custom widgets</b>. This limit is tied to your monthly event volume — accounts under 250K events/month get the free limit of 3 — not to a specific plan name.</div>)} />
 
 ### How it works
 
-Tracking custom events is one of the most powerful ways to gain insight into your product and user behavior. To make this easier, Vexo allows Premium and Enterprise users to **add custom widgets** directly to their dashboard. Each widget displays the daily usage of a selected custom event, filtered by any properties you’ve defined.
+Tracking custom events is one of the most powerful ways to gain insight into your product and user behavior. To make this easier, Vexo lets you **add custom widgets** directly to your dashboard. Each widget displays the daily usage of a selected custom event, filtered by any properties you’ve defined.
 
 Custom widgets support the same **global filters** as the rest of your dashboard, so every metric you see remains consistent and in context. You can easily compare your custom metrics alongside your main analytics data.
 

--- a/app/web-guide/web-features/dashboard/funnels/docs.mdx
+++ b/app/web-guide/web-features/dashboard/funnels/docs.mdx
@@ -1,8 +1,6 @@
-import { DocLayout, Warning, DocImage } from '../../../../../components';
+import { DocLayout, DocImage } from '../../../../../components';
 
 # Funnels
-
-<Warning message={(<div>This feature is for <b>premium & enterprise</b> accounts only</div>)} />
 
 Funnels help you visualize how users move through a series of actions on your website. You can identify where visitors drop off and where they continue, helping you optimize flows like onboarding, checkouts, or feature adoption.
 

--- a/app/web-guide/web-features/session-replays/docs.mdx
+++ b/app/web-guide/web-features/session-replays/docs.mdx
@@ -6,7 +6,7 @@ import { DocLayout, DocImage } from '../../../../components';
 
 Replays are especially useful for understanding user experience issues, tracking down bugs, or validating product changes. Combined with analytics data, they give you the full picture of *what happened* and *why*.
 
-Vexo prioritizes privacy and performance. You have full control over what is recorded — with options to blur sensitive content, limit video length, or restrict uploads to Wi‑Fi only. Replay files are optimized for efficiency, averaging around 200 KB per minute, and have minimal impact on site performance.
+Vexo prioritizes privacy and performance. Web replays are automatically capped in length (up to about 5 minutes each) and are optimized for efficiency, averaging around 200 KB per minute, so they have minimal impact on site performance. The blur, duration, and Wi‑Fi‑only controls apply to mobile (React Native) replays only — they are not available for web.
 
 This feature is ideal for observing specific user behavior, debugging issues, and validating design or content decisions based on real user interaction.
 


### PR DESCRIPTION
A code-fact-check surfaced concrete mismatches between the docs and the shipping code. This branch fixes only the doc statements that actually contradicted the code, adds the missing SDK coverage, and leaves correct claims alone. Site builds clean (`next build` → "Compiled successfully").

## Corrected

- **Free tier seats 3 → 2** — `SubscriptionService.FREE_FOREVER_SEAT_COUNT = 2`. Kept the **$5/seat** figure (it's the real current Stripe price, not a code constant). `app/settings/subscription/docs.mdx`
- **Replay max duration** — "all new session replays will be limited to 5min" → **5 min is the free default; raising it up to 15 min requires a paid plan** (changing the cap is paid-only). Also fixed an adjacent typo: "only send session replays over will" → "…over wifi". `app/react-native-guide/mobile-settings/docs.mdx`
- **Tap sampling gating** — removed "Only enabled for paid accounts"; `tapSample` is available on **all plans**. `app/react-native-guide/mobile-settings/docs.mdx`
- **Export API rate limit** — "Maximum 5 requests per application per minute" → softened to "requests may be rate limited … handle `429` by backing off". The documented interceptor is **not wired** (not registered; route pattern mismatches), so the hard 5/min figure doesn't fire. Kept the 10,000-events/request cap (correct) and the `429` error-table row. `app/settings/app-settings/export-api/docs.mdx`
- **Payment methods** — checkout sets **no `payment_method_types`** in code; the methods offered are Stripe-Dashboard-controlled. Reworded the fixed "We accept X, Y, Z" list to "managed in Stripe … currently include … may vary by region and device", and corrected the method name **"Cash Pay" → "Cash App Pay"**. `app/settings/billing/docs.mdx`
- **Web session replays** — removed the "blur / limit video length / Wi-Fi-only" controls claim; those are **mobile-only**. web-sdk `maxDuration` is hardcoded to **300 s** (not user-settable) and web-sdk has no blur/wifi options. Replaced with an accurate description + a pointer that those controls apply to mobile replays only. `app/web-guide/web-features/session-replays/docs.mdx`
- **Funnels tier gate removed** — funnels are **not** plan/tier-gated in code. Removed the "premium & enterprise only" Warning (and the now-unused `Warning` import) on both `app/react-native-guide/mobile-features/dashboard/funnels/docs.mdx` and `app/web-guide/web-features/dashboard/funnels/docs.mdx`.
- **Custom dashboards gating corrected** — not "premium & enterprise". Real gate: **free limit = 3 custom widgets, tied to event volume < 250K/month**, not to a plan name. Rewrote the Warning + the "enterprise users" prose on both `app/react-native-guide/mobile-features/dashboard/customize-dashboard/docs.mdx` and `app/web-guide/web-features/dashboard/customize-dashboard/docs.mdx`.

## Added

- **`trackError(err, { handled })`** — new "Error reporting" section; default is handled (doesn't count against crash-free rate), `{ handled: false }` marks it unhandled. `app/react-native-guide/integration/docs.mdx`
- **Event batching** — the SDK flushes at **20 events or 5 s after the first queued event** (`MAX_BATCH_SIZE=20`, `FLUSH_INTERVAL_IN_MILLIS=5000`, #64). `app/react-native-guide/integration/docs.mdx`
- **500K-free metering explainer** — added a cross-link from the SDK events list to the Subscription page's existing 500K/month allowance + rates. `app/react-native-guide/integration/docs.mdx`
- **Network ignore-list is host-anchored** — new "What's captured" section: Vexo excludes its own API traffic (matched by host) and the RN dev-server `/symbolicate` and `/logs` endpoints (exact-path match), so your own URLs that merely contain those words are still captured. `app/react-native-guide/mobile-features/dashboard/network-stats/docs.mdx`
- **Troubleshooting: background→foreground scroll stutter** — fixed in `vexo-analytics` ≥ 1.8.0; otherwise disable replay from the dashboard. The code-level `vexo('KEY', { sessionReplay: false })` switch is presented as **targeted for the next release (v1.9.1), not yet available** (refs docs issue #49 and vexo-analytics PR #95). `app/react-native-guide/integration/docs.mdx`

### Already covered (verified against origin/main, no change needed)

- **`vexo(apiKey)`** — documented and matches the shipped signature (`vexo(apiKey: string): void`). The `sessionReplay` option is NOT in `src/index.ts` on origin/main, confirming it's unshipped.
- **`identifyDevice(id | null)`** including the `null` un-identify path — already documented in both `integration` and `people`.
- **`setHeatmapSegment`** usage (≤64 chars, null clears, ≤20 distinct) — already fully documented in `session-replays-heatmaps`.
- **Args length limit (correction #1, 5120 → 65536 / reject-not-truncate)** — **no target**: grepped the whole docs repo; no page asserts any custom-event `args` length limit or truncation behavior. Nothing to correct, and it's not in the requested "add" list, so left undocumented.

## Flagged — not changed (ready-when-shipped)

Present in code and/or roadmap but intentionally left undocumented per instructions:

- **Crash / ANR APIs** — `crash.js` watchdog exists in the SDK, but only the public `trackError` is documented; crash/ANR capture APIs are not surfaced.
- **Share links** — not documented.
- **Network panel** — the existing Network Stats dashboard widget is documented (shipped); the richer "network panel" is not.
- **AI summaries** — not documented.
- **Data retention policy** (e.g. 30d free / 12mo paid) — not documented; no code-enforced TTL today.
- **`vexo(apiKey, { sessionReplay: false })`** — PR #95 open; referenced only as an upcoming v1.9.1 option, never as shipped.

## #52 / #53 overlaps

- Both PRs are **MERGED**, not open (`gh pr view 52/53 → state MERGED`). Their changes are already in the `origin/main` base this branch was cut from, so there is **no collision risk**.
- **#52 (SEO titles)** touched `page.tsx` files. Every edit here is in `docs.mdx` content files → **no file overlap**.
- **#53 (custom-events sections)** touched `custom-events/docs.mdx` (mobile + web). Those files were **not edited** here — the only fact-check item pointing at custom events (the args limit) had no target in the docs. **No overlap.**

---
**Reviewed before opening:** diff spot-checked against code — free tier 2 seats (FREE_FOREVER_SEAT_COUNT), replay 5-min free default / 15-min paid, tap sampling un-gated, funnel/dashboard tier-gates removed. `next build` clean. 11 doc files, no lockfiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
