### PR TITLE
docs: Performance monitoring + Console Logs (vexo-analytics 1.10.0)

### DIFF
--- a/app/react-native-guide/mobile-features/console-logs/docs.mdx
+++ b/app/react-native-guide/mobile-features/console-logs/docs.mdx
@@ -1,0 +1,71 @@
+import { DocLayout } from '../../../../components';
+
+# Console Logs
+
+Console Logs bring your app's own `console` output into session replays. While you watch a
+replay, the Console tab shows the log, info, warning, and error messages the app printed —
+lined up with what the user was doing — so you can debug from the same timeline you're already
+watching.
+
+**Note:** Available in `vexo-analytics` 1.10.0 or later.
+
+## What gets captured
+
+Vexo mirrors the four standard console methods — `console.log`, `console.info`,
+`console.warn`, and `console.error`. Each captured entry keeps:
+
+- the **level** (log / info / warn / error),
+- the formatted **message** (all arguments joined into one string),
+- a **timestamp**, so it can be placed on the replay timeline, and
+- the **screen** (route) the user was on when it fired.
+
+Vexo's own internal logs (the `Vexo:`-prefixed ones) are skipped, so the Console tab only ever
+shows your application's output.
+
+## Where to see them
+
+Open a session replay and expand the **DevTools** panel. Next to the **Network** tab you'll
+find a **Console** tab. It shows the captured entries synced to replay time, and lets you:
+
+- **filter by level** — log, info, warning, or error,
+- **search** the message text, and
+- **click an entry to seek** the replay to the moment that log was printed.
+
+## Automatic and gated
+
+Console capture requires no code. The SDK patches `console` when you initialize Vexo and
+passes every call straight through to the real console, so your logs still print normally in
+development and to any other logging you have.
+
+Capture follows the same gating as the rest of Vexo. It flows through the same batched
+transport and **tracking gate** as every other event, so `disableTracking()` stops it, and the
+captured logs surface only inside session replays — they follow whether session replay is
+enabled for the app.
+
+## Sanitization and truncation
+
+`console.*` accepts anything, so Vexo safely converts each argument to text on-device before it
+leaves the phone:
+
+- **Errors** become their stack trace.
+- **Circular objects** render as `[Circular]` instead of throwing.
+- **Functions** render as `[Function name]`, and `undefined` / `bigint` are handled.
+- If an object can't be serialized at all, Vexo falls back to `String(value)`.
+
+Messages are capped at **4000 characters**; anything longer is cut with a `…[truncated]`
+marker. Capturing is fully guarded — if anything goes wrong while building a log entry, the
+SDK swallows the error and still prints your original `console` call. Console capture will
+never break your app's own logging.
+
+## Privacy
+
+Console Logs reflect exactly what your code passes to `console.*`. If your app logs tokens,
+credentials, or other personal data, that text will appear in the replay's Console tab. Treat
+console output as user-visible data:
+
+- Avoid logging secrets or PII, or strip/gate those logs in production builds.
+- `disableTracking()` stops console capture along with all other tracking, and turning off
+  session replay removes the Console tab from replays.
+- The SDK never captures its own `Vexo:`-prefixed internal logs.
+
+export default ({ children }) => <DocLayout current="console-logs" previous={{href: '/react-native-guide/mobile-features/session-replays-heatmaps', label: 'Session Replays & Heatmaps'}} next={{href: '/react-native-guide/mobile-features/custom-events', label: 'Custom Events'}}>{children}</DocLayout>

--- a/app/react-native-guide/mobile-features/console-logs/page.tsx
+++ b/app/react-native-guide/mobile-features/console-logs/page.tsx
@@ -1,0 +1,5 @@
+import Docs from './docs.mdx'
+
+export default function Home() {
+    return <Docs />
+}

--- a/app/react-native-guide/mobile-features/custom-events/docs.mdx
+++ b/app/react-native-guide/mobile-features/custom-events/docs.mdx
@@ -55,4 +55,4 @@ const CheckoutComponent = () => {
 
 Custom events in Vexo are fully connected to your users and session replays. When viewing any event, you can see which users triggered it, identify your power users, and jump directly to the session replay to watch exactly what happened. Filter by user, toggle "With Recording" to find events with replays attached, and go from event to insight in just a few clicks.
 
-export default ({ children }) => <DocLayout current="custom-events" previous={{href: '/react-native-guide/mobile-features/session-replays-heatmaps', label: 'Session Replays & Heatmaps'}} next={{href: '/react-native-guide/mobile-publishing', label: 'Mobile Publishing'}}>{children}</DocLayout>
+export default ({ children }) => <DocLayout current="custom-events" previous={{href: '/react-native-guide/mobile-features/console-logs', label: 'Console Logs'}} next={{href: '/react-native-guide/mobile-publishing', label: 'Mobile Publishing'}}>{children}</DocLayout>

--- a/app/react-native-guide/mobile-features/dashboard/network-stats/docs.mdx
+++ b/app/react-native-guide/mobile-features/dashboard/network-stats/docs.mdx
@@ -40,4 +40,4 @@ The Network Stats widget respects all global dashboard filters — **date range*
 
 For example, filter by a specific country to check if API latency is higher in certain regions, or filter by app version to verify that a new release hasn't introduced regressions.
 
-export default ({ children }) => <DocLayout current="network-stats" previous={{href: '/react-native-guide/mobile-features/dashboard/errors', label: 'Errors'}} next={{href: '/react-native-guide/mobile-features/dashboard/retention', label: 'Retention'}}>{children}</DocLayout>
+export default ({ children }) => <DocLayout current="network-stats" previous={{href: '/react-native-guide/mobile-features/dashboard/errors', label: 'Errors'}} next={{href: '/react-native-guide/mobile-features/dashboard/performance', label: 'Performance'}}>{children}</DocLayout>

--- a/app/react-native-guide/mobile-features/dashboard/performance/docs.mdx
+++ b/app/react-native-guide/mobile-features/dashboard/performance/docs.mdx
@@ -1,0 +1,95 @@
+import { DocLayout } from '../../../../../components';
+
+# Performance
+
+The Performance dashboard shows how fast your app feels to real users: how long it takes to
+start, how smoothly it renders, and how long each screen takes to appear. Vexo captures these
+signals automatically on your users' devices and trends them over time and by app version.
+
+**Note:** Available in `vexo-analytics` 1.10.0 or later.
+
+## What Vexo captures
+
+Performance monitoring is built into the SDK. Once you call `vexo(...)`, three signals are
+collected on-device and sent through the same pipeline as your other events — no extra code,
+no manual instrumentation:
+
+- **App start** — how long the app takes to become ready.
+- **Frame health** — how many frames are slow or frozen while the app is on screen.
+- **Per-screen render** — how long each screen takes to appear after a navigation.
+
+## App start
+
+Vexo reports two kinds of app-start latency:
+
+- **Cold start** — the time from the JavaScript engine loading the SDK to your first screen
+  becoming ready. Reported once per launch. It is measured from JS module load rather than the
+  native process start, which is an accurate budget for the JavaScript side of startup.
+- **Warm start** — the time to become ready again when the user brings the app back from the
+  background. Measured on each background-to-foreground transition.
+
+Both are reported in milliseconds and aggregated into percentiles on the dashboard.
+
+## Frame health (slow and frozen frames)
+
+Vexo samples the JavaScript thread frame by frame and classifies each frame by how long it
+took to render:
+
+- **Slow frame** — took longer than **16 ms** (a dropped frame at 60 fps). A high slow-frame
+  rate reads as jank or stutter.
+- **Frozen frame** — took longer than **700 ms** (a freeze the user can clearly feel). Every
+  frozen frame is also counted as a slow frame.
+
+Frames are counted per screen and reported as slow, frozen, and total counts. A window is
+flushed when the user navigates to another screen, on a periodic interval while a screen stays
+open, and when the app is sent to the background.
+
+The 16 ms / 700 ms thresholds target 60 fps displays. On 90 Hz or 120 Hz screens more frames
+naturally exceed 16 ms, so treat the slow-frame rate as a relative trend to watch across
+releases rather than an absolute pass/fail line.
+
+## Per-screen render
+
+On every navigation, Vexo measures how long the new screen takes to commit its first frame
+after the route changes — a practical proxy for time-to-interactive. This is broken out per
+route so you can see which screens are slow to appear.
+
+## Automatic and privacy-gated
+
+Performance capture requires no code. It installs when you initialize the SDK and follows the
+same gating as the rest of Vexo:
+
+- It flows through the same batched transport and **tracking gate** as every other event, so
+  `disableTracking()` stops it and `enableTracking()` resumes it.
+- It never runs in **development builds** — frame timing under a paused debugger would produce
+  meaningless "frozen" frames.
+- It is **paused while the app is backgrounded** and resumes on the next foreground.
+
+## Where to find it
+
+Open the **Performance** page in your mobile app's dashboard. It has three panels:
+
+- **App start** — a percentile toggle (p50 / p75 / p90 / p99) and a cold / warm toggle, a
+  headline latency value, and a trend chart.
+- **Frame health** — a slow-frame-rate gauge plus slow-frame and frozen-frame rate trends.
+- **Per-screen render** — a table of routes with p50 / p75 / p95 render times.
+
+Like the rest of the dashboard, every panel respects the global **date range** and **app
+version** filters, so you can confirm a new release didn't regress startup or introduce jank.
+
+## Turning it off
+
+Performance capture is on by default. To disable it for a build, pass `performance: false`
+when you initialize Vexo:
+
+```js
+import { vexo } from 'vexo-analytics';
+
+vexo('YOUR_API_KEY', { performance: false });
+```
+
+All other tracking keeps working; only performance capture is turned off. Re-running `vexo()`
+overwrites the option, and `disableTracking()` stops performance capture along with everything
+else.
+
+export default ({ children }) => <DocLayout current="performance" previous={{href: '/react-native-guide/mobile-features/dashboard/network-stats', label: 'Network Stats'}} next={{href: '/react-native-guide/mobile-features/dashboard/retention', label: 'Retention'}}>{children}</DocLayout>

--- a/app/react-native-guide/mobile-features/dashboard/performance/page.tsx
+++ b/app/react-native-guide/mobile-features/dashboard/performance/page.tsx
@@ -1,0 +1,5 @@
+import Docs from './docs.mdx'
+
+export default function Home() {
+    return <Docs />
+}

--- a/app/react-native-guide/mobile-features/dashboard/retention/docs.mdx
+++ b/app/react-native-guide/mobile-features/dashboard/retention/docs.mdx
@@ -44,4 +44,4 @@ The Retention widget respects all global dashboard filters — **date range**, *
 
 For example, filter by "United States" to see if your US users retain better than global averages, or compare retention across app versions to measure the impact of product changes.
 
-export default ({ children }) => <DocLayout current="retention" previous={{href: '/react-native-guide/mobile-features/dashboard/network-stats', label: 'Network Stats'}} next={{href: '/react-native-guide/mobile-features/dashboard/customize-dashboard', label: 'Customize your Dashboard'}}>{children}</DocLayout>
+export default ({ children }) => <DocLayout current="retention" previous={{href: '/react-native-guide/mobile-features/dashboard/performance', label: 'Performance'}} next={{href: '/react-native-guide/mobile-features/dashboard/customize-dashboard', label: 'Customize your Dashboard'}}>{children}</DocLayout>

--- a/app/react-native-guide/mobile-features/session-replays-heatmaps/docs.mdx
+++ b/app/react-native-guide/mobile-features/session-replays-heatmaps/docs.mdx
@@ -90,4 +90,4 @@ A few things to keep in mind:
 - A screen's segmented screenshot is captured on the first visit *after* the segment is set. If you change the segment mid-session, it applies from the next screen visit onwards.
 - Works the same with `react-navigation` and `expo-router`—heatmaps key on route names, and the segment is orthogonal to them.
 
-export default ({ children }) => <DocLayout current="session-replays-heatmaps" previous={{href: '/react-native-guide/mobile-features/people', label: 'People'}} next={{href: '/react-native-guide/mobile-features/custom-events', label: 'Custom Events'}}>{children}</DocLayout>
+export default ({ children }) => <DocLayout current="session-replays-heatmaps" previous={{href: '/react-native-guide/mobile-features/people', label: 'People'}} next={{href: '/react-native-guide/mobile-features/console-logs', label: 'Console Logs'}}>{children}</DocLayout>

--- a/components/layoutData.tsx
+++ b/components/layoutData.tsx
@@ -53,6 +53,7 @@ export const sidebarData: SidebarData = [
                             { title: 'App Usage', name: 'app-intensity', href: '/react-native-guide/mobile-features/dashboard/app-intensity' },
                             { title: 'Errors', name: 'errors', href: '/react-native-guide/mobile-features/dashboard/errors' },
                             { title: 'Network Stats', name: 'network-stats', href: '/react-native-guide/mobile-features/dashboard/network-stats' },
+                            { title: 'Performance', name: 'performance', href: '/react-native-guide/mobile-features/dashboard/performance' },
                             { title: 'Retention', name: 'retention', href: '/react-native-guide/mobile-features/dashboard/retention' },
                             { title: 'Customize your Dashboard', name: 'customize-dashboard', href: '/react-native-guide/mobile-features/dashboard/customize-dashboard' },
                             { title: 'Funnels', name: 'funnels', href: '/react-native-guide/mobile-features/dashboard/funnels' },
@@ -60,6 +61,7 @@ export const sidebarData: SidebarData = [
                     },
                     { title: 'People', name: 'people', href: '/react-native-guide/mobile-features/people' },
                     { title: 'Session Replays & Heatmaps', name: 'session-replays-heatmaps', href: '/react-native-guide/mobile-features/session-replays-heatmaps' },
+                    { title: 'Console Logs', name: 'console-logs', href: '/react-native-guide/mobile-features/console-logs' },
                     { title: 'Custom Events', name: 'custom-events', href: '/react-native-guide/mobile-features/custom-events' },
                 ]
             },


### PR DESCRIPTION
## What

Documents the two new `vexo-analytics` SDK features shipping in **1.10.0**:

1. **Mobile performance monitoring** (issue #343 / SDK PR vexotech/vexo-analytics#98, api #408, web #368) — app-start (cold/warm) latency, slow/frozen frame health, and per-screen render timing, captured automatically as PERF events and surfaced on a new **Performance** dashboard page.
2. **Console/log capture in session replay** (issue #338 / SDK PR vexotech/vexo-analytics#99, api #410, web #369) — `console.log/info/warn/error` mirrored into the session-replay DevTools as a **Console** tab beside Network, synced to replay time.

## Release gating (read before merging)

Both features are NOT in a released SDK yet. Each page is marked **"Available in `vexo-analytics` 1.10.0 or later"** using the repo's existing version-note convention (same style as the Segments note: ``**Note:** Requires `vexo-analytics` 1.7.0 or later.``).

**This docs PR should merge WITH the 1.10.0 SDK release, not before it.** SDK PR #98 is merged but the version was intentionally held at 1.9.0; PR #99 is still open. Publishing these pages before 1.10.0 is cut would advertise features users can't yet install.

## Pages added

- `app/react-native-guide/mobile-features/dashboard/performance/` (`docs.mdx` + `page.tsx`) — new **Performance** dashboard sub-page. Mirrors the `network-stats` dashboard doc. Covers: the three captured signals (app start, frame health, per-screen render); metric meanings (cold = JS-module-load → first ready, once per launch; warm = background→active re-ready; screen render = first frame committed after a route change); frame thresholds (**slow >16 ms**, **frozen >700 ms**, frozen ⊂ slow, note that thresholds target 60 fps); that capture is automatic (no code) and gated (tracking gate / `disableTracking()`, never in dev builds, paused while backgrounded); the `performance: false` opt-out; and where it surfaces on the dashboard (app-start percentile + cold/warm panel, frame-health gauge + slow/frozen rate trends, per-screen render table; respects global date-range + app-version filters).
- `app/react-native-guide/mobile-features/console-logs/` (`docs.mdx` + `page.tsx`) — new **Console Logs** feature page next to Session Replays. Covers: what's captured (log/info/warn/error → level, message, timestamp, route; SDK's own `Vexo:` logs skipped); where it appears (replay DevTools **Console** tab beside Network, with level filter, search, click-to-seek); automatic + gated (patched at `vexo()` init, passthrough to real console, tracking-gated, tied to session replay); sanitization (Errors→stack, circular→`[Circular]`, functions/undefined/bigint handled, `String()` fallback) and truncation (4000-char cap with `…[truncated]`); and privacy (console output is user-visible data — don't log secrets/PII; `disableTracking()` and turning off session replay both stop it).

## Pages edited (nav wiring only, 1 line each)

- `components/layoutData.tsx` — added **Performance** (after Network Stats) and **Console Logs** (after Session Replays & Heatmaps) sidebar entries.
- `.../dashboard/network-stats/docs.mdx` — next → Performance.
- `.../dashboard/retention/docs.mdx` — previous → Performance.
- `.../session-replays-heatmaps/docs.mdx` — next → Console Logs.
- `.../custom-events/docs.mdx` — previous → Console Logs.

`app/sitemap.ts` auto-walks `app/`, so the new routes are picked up with no edit.

## Accuracy

Content was written from the actual PR diffs + SDK source, not guessed: SDK PRs #98 (`src/vexo/engine/perf/index.js`, `createPerfEvent`, `VexoOptions.performance`) and #99 (`src/vexo/engine/user/consoleInterceptor.js`, `createConsoleEvent`), plus web PR #368 (Performance dashboard panels) and #369 (replay Console tab UX). No screenshots referenced (no images shipped), so no broken image links.

## Build

`yarn build` (Next.js 13.4.4, production) — clean.

```
- info Compiled successfully
├ ○ /react-native-guide/mobile-features/console-logs                   1.98 kB         147 kB
├ ○ /react-native-guide/mobile-features/dashboard/performance          1.98 kB         147 kB
...
○  (Static)  automatically rendered as static HTML (uses no initial props)
Done in 34.64s.
```

Both new routes are generated as static pages. The only build warnings are the pre-existing repo-wide `metadata.metadataBase is not set` notices emitted for every page — unrelated to this change.

## Notes / flags

- Perf gating is the **tracking gate + `performance` opt-out + dev/background pauses** — it is NOT tied to session replay (documented accurately as such, rather than lumping it with the console feature's session-replay gating).
- No markdown blockquotes used (they render as `▎` on this site).


---
**⚠️ Merge with the 1.10.0 SDK release, not before** — both pages are marked "Available in vexo-analytics 1.10.0", so they should go live when the SDK (perf #98 + console #99) ships, alongside the perf/console web PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
